### PR TITLE
feat: add 'clear' command to remove all tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { addTodo, listTodos, removeTodo } = require('./todo');
+const { addTodo, listTodos, removeTodo, clearTodos } = require("./todo");
 const args = process.argv.slice(2);
 
 const command = args[0];
@@ -9,6 +9,7 @@ if (command === 'help' || args.length === 0) {
       node index.js add "Task description"    - Adds a new task
       node index.js list                       - Lists all tasks
       node index.js remove <task_index>        - Removes a task by index
+      node index.js clear                      - Removes all tasks
   `);
   return;
 }
@@ -26,6 +27,10 @@ switch (command) {
     const taskIndex = parseInt(args[1], 10);
     removeTodo(taskIndex);
     console.log(`Removed task at index: ${taskIndex}`);
+    break;
+  case 'clear':
+    clearTodos();
+    console.log('All tasks have been removed.');
     break;
   default:
     console.log('Unknown command. Use "add", "list", or "remove".');

--- a/todo.js
+++ b/todo.js
@@ -21,6 +21,12 @@ function addTodo(task) {
   saveTodos();
 }
 
+// Remove all tasks
+function clearTodos() {
+  todos = [];
+  saveTodos();
+}
+
 // List all tasks
 function listTodos() {
   if (todos.length === 0) {
@@ -45,4 +51,4 @@ function removeTodo(index) {
 // Initialize tasks on startup
 loadTodos();
 
-module.exports = { addTodo, listTodos, removeTodo };
+module.exports = { addTodo, listTodos, removeTodo , clearTodos };


### PR DESCRIPTION
# feat: add 'clear' command to remove all tasks

## Summary
This pull request introduces a new `clear` command that allows users to remove all tasks from the to-do list at once. This addresses the need for a bulk deletion feature, which was previously missing.

## Root cause
The application did not have a command or the underlying logic to delete all tasks. Users could only remove tasks one by one by their index.

## Changes
- **`todo.js`**: Added a new `clearTodos` function that erases the content of the `todos` array and saves the empty array to `todos.json`.
- **`index.js`**:
    - Added a `case` for the `clear` command to the main `switch` statement.
    - Imported and called the `clearTodos` function.
    - Updated the help message to include usage instructions for the new command.

## Testing
I performed the following manual checks to verify the functionality:
1.  Ran `node index.js add "Task 1"` and `node index.js add "Task 2"` to populate the list.
2.  Ran `node index.js list` to confirm the tasks were present.
3.  Ran `node index.js clear`. The console correctly outputted "All tasks have been removed.".
4.  Ran `node index.js list` again and confirmed the output was "No tasks yet!".

## Risk & Rollback
- **Risk**: Low. The changes are self-contained and do not affect existing commands (`add`, `list`, `remove`).
- **Rollback**: This PR can be reverted using the "Revert" button on GitHub.

## Related
- Closes #6