### PR TITLE
Add clear command to remove all tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { addTodo, listTodos, removeTodo } = require('./todo');
+const { addTodo, listTodos, removeTodo, clearTodos } = require('./todo');
 const args = process.argv.slice(2);
 
 const command = args[0];
@@ -9,6 +9,7 @@ if (command === 'help' || args.length === 0) {
       node index.js add "Task description"    - Adds a new task
       node index.js list                       - Lists all tasks
       node index.js remove <task_index>        - Removes a task by index
+      node index.js clear                      - Removes all tasks
   `);
   return;
 }
@@ -27,6 +28,10 @@ switch (command) {
     removeTodo(taskIndex);
     console.log(`Removed task at index: ${taskIndex}`);
     break;
+  case 'clear':
+    clearTodos();
+    console.log('All tasks have been cleared.');
+    break;
   default:
-    console.log('Unknown command. Use "add", "list", or "remove".');
+    console.log('Unknown command. Use "add", "list", "remove", or "clear".');
 }

--- a/todo.js
+++ b/todo.js
@@ -42,7 +42,13 @@ function removeTodo(index) {
   }
 }
 
+// Clear all tasks
+function clearTodos() {
+  todos = [];
+  saveTodos();
+}
+
 // Initialize tasks on startup
 loadTodos();
 
-module.exports = { addTodo, listTodos, removeTodo };
+module.exports = { addTodo, listTodos, removeTodo, clearTodos };


### PR DESCRIPTION
Implements a new 'clear' command that allows users to remove all tasks at once by running 'node index.js clear'. This addresses issue #6 by adding the requested functionality.

Changes:
- Added clearTodos() function in todo.js to reset task list
- Updated index.js to handle 'clear' command
- Added clear command to help text
- Updated error message to include clear option

  Closes #6

  ## Test Plan
  - [x] Added test tasks using `node index.js add`
  - [x] Verified tasks are listed with `node index.js list`
  - [x] Executed `node index.js clear` command
  - [x] Confirmed all tasks were removed
  - [x] Verified help text displays clear command