### PR TITLE
Add sorting support for task listing by name and due date

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -31,8 +31,7 @@ def add_todo(task, priority="Medium", tags=None):
     save_todos(todos)
     print(f"✅ Added: {task} [Priority: {priority}] [Tags: {', '.join(tags)}]")
 
-# List all tasks sorted by priority and optionally filtered by tag
-def list_todos(filter_tag=None):
+def list_todos(filter_tag=None, sort_by=None):
     todos = load_todos()
     if not todos:
         print("No tasks yet!")
@@ -41,13 +40,18 @@ def list_todos(filter_tag=None):
     if filter_tag:
         todos = [t for t in todos if filter_tag in t.get("tags", [])]
 
-    priority_order = {"High": 0, "Medium": 1, "Low": 2}
-    todos.sort(key=lambda x: priority_order.get(x.get("priority", "Medium")))
+    if sort_by == "name":
+        todos.sort(key=lambda x: x.get("task", "").lower())
+    elif sort_by == "due":
+        todos.sort(key=lambda x: x.get("due", ""))  
+    else:
+        priority_order = {"High": 0, "Medium": 1, "Low": 2}
+        todos.sort(key=lambda x: priority_order.get(x.get("priority", "Medium")))
 
     for i, task in enumerate(todos):
         tags = ", ".join(task.get("tags", []))
-        print(f"{i}: {task['task']} [Priority: {task['priority']}] [Tags: {tags}]")
-
+        due = task.get("due", "N/A")
+        print(f"{i}: {task['task']} [Priority: {task['priority']}] [Tags: {tags}] [Due: {due}]")
 # Remove a task by index
 def remove_todo(index):
     todos = load_todos()
@@ -106,11 +110,19 @@ def main():
 
     elif command == "list":
         filter_tag = None
+        sort_by = None
+
         if "--tag" in sys.argv:
             tag_index = sys.argv.index("--tag")
             if tag_index + 1 < len(sys.argv):
                 filter_tag = sys.argv[tag_index + 1]
-        list_todos(filter_tag)
+
+        if "--sort" in sys.argv:
+            sort_index = sys.argv.index("--sort")
+            if sort_index + 1 < len(sys.argv):
+                sort_by = sys.argv[sort_index + 1]
+
+        list_todos(filter_tag, sort_by)
 
     elif command == "remove" and len(sys.argv) == 3:
         try:


### PR DESCRIPTION
### ✨ Feature: Task Sorting Support

This PR adds sorting functionality to the CLI todo app.

#### ✅ Changes:
- `list` command now supports `--sort name` and `--sort due` flags.
- Tasks can be sorted alphabetically or by due date (if present).
- Sorting works alongside existing tag filtering.

####  Example Usage:
```bash
python todo.py list --sort name
python todo.py list --sort due
python todo.py list --tag work --sort name
