### PR TITLE
feat: add done command to mark todos as complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const {
     listTodos,
     removeTodo,
     editTodo,
+    markDone,
     clearTodos,
 } = require("./todo");
 const args = process.argv.slice(2);
@@ -56,6 +57,16 @@ switch (command) {
         clearTodos();
         console.log("All tasks have been cleared.");
         break;
+    case "done":
+        const doneIndex = parseInt(args[1], 10);
+        if (isNaN(doneIndex)) {
+            console.log("Error: Please provide a valid task index.");
+            console.log('Usage: node index.js done <task_index>');
+        } else {
+            markDone(doneIndex);
+        }
+        break;
+ 
     default:
         console.log(
             'Unknown command. Use "add", "list", "remove", "edit", or "clear".'

--- a/todo.js
+++ b/todo.js
@@ -55,6 +55,17 @@ function editTodo(index, newDescription) {
         console.log("Invalid task index.");
     }
 }
+function markDone(index) {
+    const todos = getTodos();
+    if (index < 0 || index >= todos.length) {
+        console.log("❌ Invalid task index.");
+        return;
+    }
+
+    todos[index].done = true; // mark the task as done
+    saveTodos(todos);
+    console.log(`✅ Task "${todos[index].task}" marked as done.`);
+}
 
 // Clear all tasks
 function clearTodos() {
@@ -65,4 +76,4 @@ function clearTodos() {
 // Initialize tasks on startup
 loadTodos();
 
-module.exports = { addTodo, listTodos, removeTodo, editTodo, clearTodos };
+module.exports = { addTodo, listTodos, removeTodo, editTodo, markDone, clearTodos };


### PR DESCRIPTION
What:
- Add a `done` command to mark a todo item as completed from the CLI.

Why:
- Allows users to mark tasks done without editing the JSON manually.

How:
- Implemented `markDone()` in `todo.js` to set `todos[index].done = true` and save.
- Wired the `done` command in `index.js` so the CLI calls `markDone()`.

Test plan:
- Ran local smoke tests:
  - `node index.js list` — verified list prints.
  - `node index.js done <index>` — verified the item at <index> is marked done and saved.
- (Optional) Added unit tests: N/A (or list test files if present).

Notes:
- Indexing: (state whether CLI uses 0-based or 1-based indexing, e.g., "uses 0-based indexes").
- No breaking changes.

Closes: #<issue-number>  (remove or replace with actual issue number if none)